### PR TITLE
Added the ability to have custom javascript code in a java interface.

### DIFF
--- a/dragome-web/src/main/java/com/dragome/web/enhancers/jsdelegate/DefaultDelegateStrategy.java
+++ b/dragome-web/src/main/java/com/dragome/web/enhancers/jsdelegate/DefaultDelegateStrategy.java
@@ -14,33 +14,28 @@ package com.dragome.web.enhancers.jsdelegate;
 import com.dragome.web.enhancers.jsdelegate.interfaces.DelegateStrategy;
 import com.dragome.web.enhancers.jsdelegate.interfaces.SubTypeFactory;
 
+import javassist.CtClass;
 import javassist.CtMethod;
 import javassist.NotFoundException;
 
 public class DefaultDelegateStrategy implements DelegateStrategy
 {
-	public boolean isPropertyWriteMethod(CtMethod method)
-	{
-		try
-		{
-			return method.getName().startsWith("set") && method.getParameterTypes().length == 1;
+	@Override
+	public String createMethodCall(CtMethod method, StringBuffer code, String params) throws NotFoundException  {
+		
+		if(method.getName().startsWith("set") && method.getParameterTypes().length == 1)
+		{ //
+			CtClass parameterType= method.getParameterTypes()[0];
+			code.append("$eval$(\"this.node." + method.getName().toLowerCase().charAt(3) + method.getName().substring(4) + "= " + JsDelegateGenerator.createVariableForEval("$1", parameterType) + "\", this);");
+			return null;
 		}
-		catch (NotFoundException e)
+		else if(method.getName().startsWith("get") && method.getParameterTypes().length == 0)
 		{
-			throw new RuntimeException(e);
+			code.append("$eval$(\"this.node." + method.getName().toLowerCase().charAt(3) + method.getName().substring(4) + "\", this);");
+			return null;
 		}
-	}
-	
-	public boolean isPropertyReadMethod(CtMethod method)
-	{
-		try
-		{
-			return method.getName().startsWith("get") && method.getParameterTypes().length == 0;
-		}
-		catch (NotFoundException e)
-		{
-			throw new RuntimeException(e);
-		}
+		
+		return null;
 	}
 
 	public String getSubTypeExtractorFor(Class<?> interface1, String methodName)

--- a/dragome-web/src/main/java/com/dragome/web/enhancers/jsdelegate/interfaces/DelegateStrategy.java
+++ b/dragome-web/src/main/java/com/dragome/web/enhancers/jsdelegate/interfaces/DelegateStrategy.java
@@ -12,12 +12,15 @@
 package com.dragome.web.enhancers.jsdelegate.interfaces;
 
 import javassist.CtMethod;
+import javassist.NotFoundException;
 
 public interface DelegateStrategy
 {
-	boolean isPropertyWriteMethod(CtMethod method);
-
-	boolean isPropertyReadMethod(CtMethod method);
+	/**
+	 * This makes you have a custom javascript code for interface methods. For a custom code you can return javascript code in a string or use the rawCode param and return null. <br>
+	 * Returning null without touching rawCode will use a generic code. Javascript parameters is already added for you. You access them by using $1, $2 and so on.
+	 */
+	String createMethodCall(CtMethod method, StringBuffer rawCode, String params) throws NotFoundException;
 
 	String getSubTypeExtractorFor(Class<?> interface1, String methodName);
 


### PR DESCRIPTION
This add the ability to do custom code for a method in a interface.

set(int,int) and get(int) does not exist in javascript typedarray so I dont let Delegator class generate the code for it (which will crash if you try to call it) and add my own code.

Example:
```Java
jsDelegateGenerator= new JsDelegateGenerator(Utils.createTempDir("jsdelegate"), classpath.replace(";", ":"), new DefaultDelegateStrategy()
		{
			@Override
			public String createMethodCall(CtMethod method, StringBuffer code, String params) throws NotFoundException 
			{	//	code.append("   $eval$(\"console.log($1);\", this);   ");
				String longName = method.getLongName();
				if(longName.contains("Int32Array.set(int,int)") || longName.contains("Int16Array.set(int,int)") || longName.contains("Int8Array.set(int,int)") || longName.contains("Uint8ClampedArray.set(int,int)") ||
						longName.contains("Uint32Array.set(int,int)") || longName.contains("Uint16Array.set(int,int)") || longName.contains("Uint8Array.set(int,int)") ||
						longName.contains("Float32Array.set(int,float)") || longName.contains("Float64Array.set(int,float)"))
					return "this.node[$1] = $2;";
				else
				if(longName.contains("Int32Array.get(int)") || longName.contains("Int16Array.get(int)") || longName.contains("Int8Array.get(int)") || longName.contains("Uint8ClampedArray.get(int)") ||
						longName.contains("Uint32Array.get(int)") || longName.contains("Uint16Array.get(int)") || longName.contains("Uint8Array.get(int)") ||
						longName.contains("Float32Array.get(int)") || longName.contains("Float64Array.get(int)"))
					return "this.node[$1];";
				else
					return super.createMethodCall(method, code, params);
			}
		});
```

for raw code you can look at the comment (//) line or DefaultDelegateStrategy class.