### PR TITLE
Improved local method alias when calling java from javascript.

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/generators/DragomeJavaScriptGenerator.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/generators/DragomeJavaScriptGenerator.java
@@ -341,17 +341,7 @@ public class DragomeJavaScriptGenerator extends Generator
 			closingString= "}";
 		}
 
-		Iterator<VariableDeclaration> iterator= method.getParameters().iterator();
-		while (iterator.hasNext())
-		{
-			VariableDeclaration decl= iterator.next();
-
-			if (hasToEscapeVariable(decl.getName()))
-				print("_");
-			decl.visit(this);
-			print(iterator.hasNext() ? ", " : "");
-		}
-
+		printParams(method);
 		println(")");
 		println("{");
 
@@ -389,7 +379,11 @@ public class DragomeJavaScriptGenerator extends Generator
 		if (local_alias != null)
 		{
 			print(", \n");
-			print(local_alias + ": function() {return this." + signatureReplaced + "(arguments)}");
+			print(local_alias + ": function(");
+			printParams(method);
+			print(") {return this." + signatureReplaced + "(");
+			printParams(method);
+			print(")}");
 		}
 
 		//println(",");
@@ -397,6 +391,21 @@ public class DragomeJavaScriptGenerator extends Generator
 		unit.setData(reset());
 		Log.getLogger().debug("Generating JavaScript for " + unit);
 	}
+	
+	private void printParams(MethodDeclaration method)
+	{
+		Iterator<VariableDeclaration> iterator= method.getParameters().iterator();
+		while (iterator.hasNext())
+		{
+			VariableDeclaration decl= iterator.next();
+
+			if (hasToEscapeVariable(decl.getName()))
+				print("_");
+			decl.visit(this);
+			print(iterator.hasNext() ? ", " : "");
+		}
+	}
+	
 	public static String normalizeExpression(Object object)
 	{
 		if (object instanceof Signature)


### PR DESCRIPTION
This is a small improvement/fix for local method alias.  The code before would not match the parameters correctly because it was a array.

Example:  my allias is onReadyStateChangee

Code Generated Before:
```javascript
$onReadyStateChange___com_badlogic_gdx_backends_dragome_js_XMLHttpRequest$void: function (xhr)
{
	L1: {
		if ((xhr.$getReadyState$int()) != 4) {
			break L1;
		}
		L2: {
			if ((xhr.$getStatus$int()) == 200) {
				break L2;
			}
			this.$$$listener.$onFailure$void();
			break L1;
		}
		this.$$$listener.$onSuccess___java_lang_Object$void(xhr.$getResponseText$java_lang_String());
	}
}, 
onReadyStateChangee: function() {return this.$onReadyStateChange___com_badlogic_gdx_backends_dragome_js_XMLHttpRequest$void(arguments)}
}
```
The generated code above will give a error because it pass a array and not the parameters.  to work all xhr variables would need to be xhr[0].####


Code Generated After:
```javascript
$onReadyStateChange___com_badlogic_gdx_backends_dragome_js_XMLHttpRequest$void: function (xhr)
{
	L1: {
		if ((xhr.$getReadyState$int()) != 4) {
			break L1;
		}
		L2: {
			if ((xhr.$getStatus$int()) == 200) {
				break L2;
			}
			this.$$$listener.$onFailure$void();
			break L1;
		}
		this.$$$listener.$onSuccess___java_lang_Object$void(xhr.$getResponseText$java_lang_String());
	}
}, 
onReadyStateChangee: function(xhr) {return this.$onReadyStateChange___com_badlogic_gdx_backends_dragome_js_XMLHttpRequest$void(xhr)}
}
```
Now the fix match correctly the number of parameters. 