### PR TITLE
Fix trying to access a null variable. Fix boolean parameter being a

### DIFF
--- a/dragome-web/src/main/java/com/dragome/web/enhancers/jsdelegate/JsDelegateGenerator.java
+++ b/dragome-web/src/main/java/com/dragome/web/enhancers/jsdelegate/JsDelegateGenerator.java
@@ -218,9 +218,7 @@ public class JsDelegateGenerator
 	{
 		String javaName= toJavaName(ctClass);
 
-		if (javaName.equals(Boolean.class.getName()) || javaName.equals(boolean.class.getName()))
-			return string + " + \"\"";
-		else if (javaName.equals(Integer.class.getName()) || javaName.equals(int.class.getName()) || //
+		if (javaName.equals(Integer.class.getName()) || javaName.equals(int.class.getName()) || //
 				javaName.equals(Double.class.getName()) || javaName.equals(double.class.getName()) || //
 				javaName.equals(Short.class.getName()) || javaName.equals(short.class.getName()) || //
 				javaName.equals(Float.class.getName()) || javaName.equals(float.class.getName()) || //
@@ -233,7 +231,7 @@ public class JsDelegateGenerator
 	public static String createVariableForEval(String string, CtClass ctClass)
 	{
 		if (ctClass.isInterface())
-			return string + ".node";
+			return string + " ? " + string + ".node" + " : " + string;
 		else
 			return string;
 	}


### PR DESCRIPTION
This is a multiple fix pull.  

The first issue is when a boolean is passed by parameter. It is adding " " (commas) next to the js boolean variable and that is converting to string which will fail if it tries to use it as a boolean. So the fix is to return the variable as it is ( maybe cast to boolean ? ).

The second issue is when a parameter is a interface and its null.  There is a case that you can pass a null (interface) parameter to webgl  and the code is trying to access "string.node" and string is null.  So the fix is just to use ".node" only if its not null. 

using typeof could be better?