### PR TITLE
Prints ';' if lastchar is not a ';'

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/generators/DragomeJavaScriptGenerator.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/generators/DragomeJavaScriptGenerator.java
@@ -589,7 +589,11 @@ public class DragomeJavaScriptGenerator extends Generator
 			{
 				println("");
 			}
-			else if(lastChar != ';')
+			else if(lastChar == ';')
+			{
+				getOutputStream().println("");
+			}
+			else
 			{
 				println(";");
 			}

--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/generators/DragomeJavaScriptGenerator.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/generators/DragomeJavaScriptGenerator.java
@@ -589,7 +589,7 @@ public class DragomeJavaScriptGenerator extends Generator
 			{
 				println("");
 			}
-			else
+			else if(lastChar != ';')
 			{
 				println(";");
 			}


### PR DESCRIPTION
This stop having double ';' when its already included in ScriptHelper.