### PR TITLE
Fix delegate classpath having single forward slash

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/DragomeJsCompiler.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/DragomeJsCompiler.java
@@ -274,7 +274,7 @@ public class DragomeJsCompiler implements BytecodeToJavascriptCompiler
 		Collection<String> allFilesInClasspath= fileManager.getAllFilesInClasspath();
 		for (String file : allFilesInClasspath)
 		{
-			assembly.resolveNoTainting(file.replace(File.separator, "."));
+			assembly.resolveNoTainting(file.replace(File.separator, ".").replace("/", "."));
 		}
 
 		assembly.addEntryPoint(assembly.getEntryPointClassName() + "#onCreate()void");


### PR DESCRIPTION
Some classes have single forward slash while others have double forward slash. This fix the single slash.