### PR TITLE
Option to disable caching

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/DragomeJsCompiler.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/DragomeJsCompiler.java
@@ -188,7 +188,7 @@ public class DragomeJsCompiler implements BytecodeToJavascriptCompiler
 			throw new RuntimeException("Field assembly.entryPointClassName must be set");
 		}
 
-		if (cacheFile == null)
+		if (compilerConfiguration.isCaching() && cacheFile == null)
 		{
 			String property= "target";
 

--- a/dragome-js-commons/src/main/java/com/dragome/commons/DefaultDragomeConfigurator.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/DefaultDragomeConfigurator.java
@@ -144,4 +144,9 @@ public class DefaultDragomeConfigurator implements DragomeConfigurator
 	{
 		return null;
 	}
+
+	@Override
+	public boolean isCaching() {
+		return true;
+	}
 }

--- a/dragome-js-commons/src/main/java/com/dragome/commons/DragomeConfigurator.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/DragomeConfigurator.java
@@ -36,6 +36,7 @@ public interface DragomeConfigurator
 	public boolean isCheckingCast();
 	List<ClasspathEntry> getExtraClasspath(Classpath classPath);
 	boolean isRemoveUnusedCode();
+	boolean isCaching();
 	public void sortClassPath(Classpath classPath);
 	URL getAdditionalCodeKeepConfigFile();
 }

--- a/dragome-js-commons/src/main/java/com/dragome/commons/compiler/BytecodeToJavascriptCompilerConfiguration.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/compiler/BytecodeToJavascriptCompilerConfiguration.java
@@ -28,8 +28,9 @@ public class BytecodeToJavascriptCompilerConfiguration
 	private BytecodeTransformer bytecodeTransformer;
 	private ClasspathFileFilter classpathFilter;
 	private boolean checkingCast;
+	private boolean isCaching;
 
-	public BytecodeToJavascriptCompilerConfiguration(Classpath classPath, String targetDir, String mainClassName, CompilerType compilerType, BytecodeTransformer bytecodeTransformer, ClasspathFileFilter classpathFilter, boolean isCheckingCast)
+	public BytecodeToJavascriptCompilerConfiguration(Classpath classPath, String targetDir, String mainClassName, CompilerType compilerType, BytecodeTransformer bytecodeTransformer, ClasspathFileFilter classpathFilter, boolean isCheckingCast, boolean isCaching)
 	{
 		this.classPath= classPath;
 		this.targetDir= targetDir;
@@ -38,6 +39,7 @@ public class BytecodeToJavascriptCompilerConfiguration
 		this.bytecodeTransformer= bytecodeTransformer;
 		this.classpathFilter= classpathFilter;
 		this.checkingCast= isCheckingCast;
+		this.isCaching = isCaching;
 	}
 
 	public Classpath getClasspath()
@@ -73,5 +75,10 @@ public class BytecodeToJavascriptCompilerConfiguration
 	public boolean isCheckingCast()
 	{
 		return checkingCast;
+	}
+	
+	public boolean isCaching()
+	{
+		return isCaching;
 	}
 }

--- a/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
+++ b/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
@@ -63,7 +63,7 @@ public class DragomeCompilerLauncher
 
 		classPath.addEntries(extraClasspath);
 
-		BytecodeToJavascriptCompilerConfiguration compilerConfiguration= new BytecodeToJavascriptCompilerConfiguration(classPath, target, mainClassName, defaultCompilerType, bytecodeTransformer, classpathFilter, configurator.isCheckingCast());
+		BytecodeToJavascriptCompilerConfiguration compilerConfiguration= new BytecodeToJavascriptCompilerConfiguration(classPath, target, mainClassName, defaultCompilerType, bytecodeTransformer, classpathFilter, configurator.isCheckingCast(), configurator.isCaching());
 		bytecodeToJavascriptCompiler.configure(compilerConfiguration);
 		bytecodeToJavascriptCompiler.compile();
 	}


### PR DESCRIPTION
Cache dont always work. Sometimes there is a execution error with a missing class because of cache file.  Its good to have this option so there is no need to manually delete it.

#101