### PR TITLE
Classpath improvements

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/DragomeJsCompiler.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/DragomeJsCompiler.java
@@ -229,7 +229,7 @@ public class DragomeJsCompiler implements BytecodeToJavascriptCompiler
 		//		System.out.println((char) 27 + "[01;31m;This text is red." + (char) 27 + "[00;00m");
 		//		System.out.println((char) 27 + "[01;32m;This text is green." + (char) 27 + "[00;00m");
 
-		fileManager= new FileManager(classpath, classpathFilter);
+		fileManager= new FileManager(classpath, null); // Change to get classes from jar. This jar is already filtered
 		//	Project.singleton= null; //TODO revisar esto, impide cacheo!!
 		Project project= Project.createSingleton(getCacheFile());
 		assembly.setProject(project);

--- a/dragome-js-commons/src/main/java/com/dragome/commons/DefaultDragomeConfigurator.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/DefaultDragomeConfigurator.java
@@ -24,7 +24,6 @@ import com.dragome.commons.compiler.BytecodeTransformer;
 import com.dragome.commons.compiler.annotations.CompilerType;
 import com.dragome.commons.compiler.classpath.Classpath;
 import com.dragome.commons.compiler.classpath.ClasspathEntry;
-import com.dragome.commons.compiler.classpath.ClasspathFile;
 import com.dragome.commons.compiler.classpath.ClasspathFileFilter;
 
 @DragomeConfiguratorImplementor
@@ -88,16 +87,46 @@ public class DefaultDragomeConfigurator implements DragomeConfigurator
 	public boolean filterClassPath(String classpathEntry)
 	{
 		boolean include= false;
-
-		include|= classpathEntry.contains("dragome-js-commons-");
-		include|= classpathEntry.contains("dragome-w3c-standards-");
-		include|= classpathEntry.contains("dragome-js-jre-");
-		include|= classpathEntry.contains("dragome-core-");
-		include|= classpathEntry.contains("dragome-web-");
-		include|= classpathEntry.contains("dragome-guia-");
-		include|= classpathEntry.contains("dragome-form-bindings-");
-		include|= classpathEntry.contains("dragome-method-logger-");
-
+		if(classpathEntry.contains("dragome-js-commons")) {
+			include|= classpathEntry.contains("dragome-js-commons-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-w3c-standards")) {
+			include|= classpathEntry.contains("dragome-w3c-standards-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-js-jre")) {
+			include|= classpathEntry.contains("dragome-js-jre-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-core")) {
+			include|= classpathEntry.contains("dragome-core-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-web")) {
+			include|= classpathEntry.contains("dragome-web-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-guia")) {
+			include|= classpathEntry.contains("dragome-guia-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-form-bindings")) {
+			include|= classpathEntry.contains("dragome-form-bindings-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
+		else if(classpathEntry.contains("dragome-method-logger")) {
+			include|= classpathEntry.contains("dragome-method-logger-");
+			include|= classpathEntry.contains("\\bin");
+			include|= classpathEntry.contains("\\classes");
+		}
 		return include;
 	}
 
@@ -148,5 +177,10 @@ public class DefaultDragomeConfigurator implements DragomeConfigurator
 	@Override
 	public boolean isCaching() {
 		return true;
+	}
+
+	@Override
+	public String getCompiledPath() {
+		return null;
 	}
 }

--- a/dragome-js-commons/src/main/java/com/dragome/commons/DragomeConfigurator.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/DragomeConfigurator.java
@@ -37,6 +37,7 @@ public interface DragomeConfigurator
 	List<ClasspathEntry> getExtraClasspath(Classpath classPath);
 	boolean isRemoveUnusedCode();
 	boolean isCaching();
+	String getCompiledPath();
 	public void sortClassPath(Classpath classPath);
 	URL getAdditionalCodeKeepConfigFile();
 }

--- a/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/ClasspathEntry.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/ClasspathEntry.java
@@ -1,5 +1,6 @@
 package com.dragome.commons.compiler.classpath;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.jar.JarOutputStream;
 
@@ -7,6 +8,6 @@ public interface ClasspathEntry
 {
 	ClasspathFile getClasspathFileOf(String relativeName);
 	List<String> getAllFilesNamesFiltering(ClasspathFileFilter classpathFilter);
-	void copyFilesToJar(JarOutputStream jos);
+	void copyFilesToJar(JarOutputStream jos, ArrayList<String> keepClass);
 	String getName();
 }

--- a/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/FolderClasspathEntry.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/FolderClasspathEntry.java
@@ -53,11 +53,11 @@ public class FolderClasspathEntry implements ClasspathEntry
 		return new FolderClasspathEntry(new File(classPathEntry));
 	}
 
-	public void copyFilesToJar(JarOutputStream jos)
+	public void copyFilesToJar(JarOutputStream jos, ArrayList<String> keepClass)
 	{
 		try
 		{
-			CopyUtils.copyClassToJarFile(folder, jos);
+			CopyUtils.copyClassToJarFile(folder, jos, keepClass);
 		}
 		catch (Exception e)
 		{

--- a/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/JarClasspathEntry.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/JarClasspathEntry.java
@@ -25,11 +25,16 @@ public class JarClasspathEntry implements ClasspathEntry
 
 	public ClasspathFile getClasspathFileOf(String relativeName)
 	{
-		JarEntry entry= jarFile.getJarEntry(relativeName);
-		if (entry != null)
-			return new InsideJarClasspathFile(jarFile, entry, relativeName);
-		else
-			return null;
+		// There is a "bug" that using getJarEntry with "/" fails and "\\" succeed and vice versa. so solution is to loop all class
+		final Enumeration<JarEntry> entries= jarFile.entries();
+		while (entries.hasMoreElements())
+		{
+				final JarEntry entry= entries.nextElement();
+				final String entryName= entry.getName().replace("\\", "/"); // force all path to "/" if its using "\\"
+				if(relativeName.equals(entryName))
+					return new InsideJarClasspathFile(jarFile, entry, relativeName);
+		}
+		return null;
 	}
 
 	private List<String> findClassesInJar(JarFile jarFile)
@@ -79,11 +84,11 @@ public class JarClasspathEntry implements ClasspathEntry
 		}
 	}
 
-	public void copyFilesToJar(JarOutputStream jos)
+	public void copyFilesToJar(JarOutputStream jos, ArrayList<String> keepClass)
 	{
 		try
 		{
-			CopyUtils.copyJarFile(jarFile, jos);
+			CopyUtils.copyJarFile(jarFile, jos, keepClass);
 		}
 		catch (IOException e)
 		{

--- a/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/VirtualFolderClasspathEntry.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/VirtualFolderClasspathEntry.java
@@ -39,7 +39,7 @@ public class VirtualFolderClasspathEntry implements ClasspathEntry
 		return files;
 	}
 
-	public void copyFilesToJar(JarOutputStream jos)
+	public void copyFilesToJar(JarOutputStream jos, ArrayList<String> keepClass)
 	{
 		for (ClasspathFile classpathFile : classpathFiles)
 			CopyUtils.addEntryToJar(jos, classpathFile.openInputStream(), classpathFile.getFilename().replace(".class", ""));

--- a/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
@@ -23,7 +23,7 @@ public class TestsConfigurator extends DomHandlerApplicationConfigurator {
 		boolean include = super.filterClassPath(classpathEntry);
 		include |= classpathEntry.contains("junit-4");
 		include |= classpathEntry.contains("hamcrest-core");
-		include |= classpathEntry.contains("classes");
+		include |= classpathEntry.contains("test-classes");
 
 		return include;
 	}

--- a/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
@@ -1,14 +1,27 @@
 package com.dragome.tests;
 
+import java.io.File;
 import java.net.URL;
 
 import com.dragome.commons.DragomeConfiguratorImplementor;
 import com.dragome.web.config.DomHandlerApplicationConfigurator;
+import com.dragome.web.helpers.serverside.DefaultClasspathFilter;
 
 @DragomeConfiguratorImplementor(priority = 1)
 public class TestsConfigurator extends DomHandlerApplicationConfigurator {
 	public TestsConfigurator() {
 		super();
+
+		setClasspathFilter( new DefaultClasspathFilter() {
+			
+			@Override
+			public boolean accept(File pathname, File folder) {
+				boolean flag = super.accept(pathname, folder);
+				if(pathname.getAbsolutePath().contains("TestsConfigurator"))
+					flag = false; // ignore this class
+				return flag;
+			}
+		});
 	}
 
 	public boolean isRemoveUnusedCode() {

--- a/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
@@ -27,4 +27,9 @@ public class TestsConfigurator extends DomHandlerApplicationConfigurator {
 
 		return include;
 	}
+
+	@Override
+	public boolean isCaching() {
+		return false;
+	}
 }

--- a/dragome-web/pom.xml
+++ b/dragome-web/pom.xml
@@ -101,7 +101,7 @@
   <dependency>
    <groupId>org.atmosphere</groupId>
    <artifactId>atmosphere-runtime</artifactId>
-   <version>2.1.3</version>
+   <version>2.4.5</version>
   </dependency>
 
   <dependency>

--- a/dragome-web/pom.xml
+++ b/dragome-web/pom.xml
@@ -104,6 +104,47 @@
    <version>2.1.3</version>
   </dependency>
 
+  <dependency>
+   <groupId>org.apache.bcel</groupId>
+   <artifactId>bcel</artifactId>
+   <version>6.0-SNAPSHOT</version>
+  </dependency>
+
+  <dependency>
+   <groupId>org.ow2.asm</groupId>
+   <artifactId>asm-all</artifactId>
+   <version>5.0.2</version>
+  </dependency>
+
+  <dependency>
+   <groupId>org.jdom</groupId>
+   <artifactId>jdom</artifactId>
+   <version>1.1</version>
+  </dependency>
+
+  <dependency>
+   <groupId>javolution</groupId>
+   <artifactId>javolution</artifactId>
+   <version>5.4.5</version>
+  </dependency>
+
+  <dependency>
+   <groupId>net.sf.saxon</groupId>
+   <artifactId>saxon</artifactId>
+   <version>9</version>
+  </dependency>
+
+  <dependency>
+   <groupId>net.sf.saxon</groupId>
+   <artifactId>saxon-jdom</artifactId>
+   <version>9</version>
+  </dependency>
+
+  <dependency>
+   <groupId>net.jpountz.lz4</groupId>
+   <artifactId>lz4</artifactId>
+   <version>1.3.0</version>
+  </dependency>
 
   <dependency>
    <groupId>com.dragome</groupId>

--- a/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
+++ b/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
@@ -14,10 +14,17 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.jar.JarOutputStream;
 import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
 
 import com.dragome.commons.DragomeConfigurator;
 import com.dragome.commons.compiler.BytecodeToJavascriptCompiler;
@@ -31,6 +38,7 @@ import com.dragome.commons.compiler.classpath.JarClasspathEntry;
 import com.dragome.services.ServiceLocator;
 import com.dragome.services.WebServiceLocator;
 import com.dragome.view.VisualActivity;
+import com.dragome.web.serverside.compile.ClasspathFilteredClasses;
 
 import proguard.Configuration;
 import proguard.ConfigurationParser;
@@ -55,12 +63,8 @@ public class DragomeCompilerLauncher
 		BytecodeToJavascriptCompiler bytecodeToJavascriptCompiler= WebServiceLocator.getInstance().getBytecodeToJavascriptCompiler();
 
 		configurator.sortClassPath(classPath);
+		classPath = process(classPath, configurator);
 		List<ClasspathEntry> extraClasspath= configurator.getExtraClasspath(classPath);
-		classPath.addEntries(extraClasspath);
-
-		if (configurator.isRemoveUnusedCode())
-			classPath= optimize(classPath, serviceLocator, configurator);
-
 		classPath.addEntries(extraClasspath);
 
 		BytecodeToJavascriptCompilerConfiguration compilerConfiguration= new BytecodeToJavascriptCompilerConfiguration(classPath, target, mainClassName, defaultCompilerType, bytecodeTransformer, classpathFilter, configurator.isCheckingCast(), configurator.isCaching());
@@ -68,21 +72,50 @@ public class DragomeCompilerLauncher
 		bytecodeToJavascriptCompiler.compile();
 	}
 
-	private static Classpath optimize(Classpath classPath, ServiceLocator serviceLocator, DragomeConfigurator configurator)
+	private static Classpath process(Classpath classPath, DragomeConfigurator configurator)
 	{
+		ClasspathFileFilter classpathFilter = configurator.getClasspathFilter();
+		HashSet<String> tmp = new HashSet<String>();
+		Collection<ClasspathFilteredClasses> files= new ArrayList<ClasspathFilteredClasses>();
+
+		for (ClasspathEntry classpathEntry : classPath.getEntries()) { // add all filtered classes 
+			List<String> allFilesNamesFiltering = classpathEntry.getAllFilesNamesFiltering(classpathFilter);
+			ClasspathFilteredClasses g = new ClasspathFilteredClasses();
+			g.classpathEntry = classpathEntry;
+			for (String clazz : allFilesNamesFiltering) {
+				clazz = clazz + ".class";
+				if(tmp.contains(clazz) == false) {
+					tmp.add(clazz);
+					g.files.add(clazz);
+				}
+			}
+			files.add(g);
+		}
+
 		try
 		{
-			File file= File.createTempFile("dragome-merged-", ".jar");
+			String path = null;
+
+			String tempDir = System.getProperty("java.io.tmpdir");
+			File tmpDir = new File(tempDir + File.separatorChar + "draogmeTemp");
+			Path tmpPath = tmpDir.toPath();
+			FileUtils.deleteDirectory(tmpDir);
+			Files.createDirectories(tmpPath);
+			File file = Files.createTempFile(tmpPath, "dragome-merged-", ".jar").toFile();
 			file.deleteOnExit();
+			path = file.getAbsolutePath();
 
 			try (JarOutputStream jos= new JarOutputStream(new FileOutputStream(file)))
 			{
-				List<ClasspathEntry> entries= classPath.getEntries();
-				for (ClasspathEntry classpathEntry : entries)
-					classpathEntry.copyFilesToJar(jos);
+				for (ClasspathFilteredClasses group : files) {
+					group.classpathEntry.copyFilesToJar(jos, group.files);  // copy all filtered classes and resources to jar;
+				}
 			}
-
-			return runProguard(file, configurator);
+			if(configurator.isRemoveUnusedCode()) {
+				return runProguard(file, configurator);
+			}
+			else
+				return new Classpath(JarClasspathEntry.createFromPath(path));
 		}
 		catch (Exception e)
 		{

--- a/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
+++ b/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
@@ -97,7 +97,7 @@ public class DragomeCompilerLauncher
 			String path = null;
 
 			String tempDir = System.getProperty("java.io.tmpdir");
-			File tmpDir = new File(tempDir + File.separatorChar + "draogmeTemp");
+			File tmpDir = new File(tempDir + File.separatorChar + "dragomeTemp");
 			Path tmpPath = tmpDir.toPath();
 			FileUtils.deleteDirectory(tmpDir);
 			Files.createDirectories(tmpPath);

--- a/dragome-web/src/main/java/com/dragome/web/serverside/compile/ClasspathFilteredClasses.java
+++ b/dragome-web/src/main/java/com/dragome/web/serverside/compile/ClasspathFilteredClasses.java
@@ -1,0 +1,10 @@
+package com.dragome.web.serverside.compile;
+
+import java.util.ArrayList;
+
+import com.dragome.commons.compiler.classpath.ClasspathEntry;
+
+public class ClasspathFilteredClasses {
+	public ClasspathEntry classpathEntry;
+	public final ArrayList<String> files = new ArrayList<String>();
+}

--- a/dragome-web/src/main/java/com/dragome/web/serverside/servlets/CompilerServlet.java
+++ b/dragome-web/src/main/java/com/dragome/web/serverside/servlets/CompilerServlet.java
@@ -65,7 +65,7 @@ public class CompilerServlet extends GetPostServlet
 				boolean isClassesFolder= i.toString().endsWith("/classes/") || i.toString().endsWith("/classes");
 				boolean addToClasspath= ServiceLocator.getInstance().getConfigurator().filterClassPath(classPathEntry);
 
-				if (isClassesFolder || addToClasspath)
+				if (addToClasspath)
 					classPath.addEntry(classPathEntry);
 
 				if (isClassesFolder)
@@ -73,8 +73,13 @@ public class CompilerServlet extends GetPostServlet
 
 				LOGGER.log(Level.INFO, "classpath entry: " + classPathEntry);
 			}
-
-			final String path= new File(new java.io.File(classesFolder).getParentFile().getParentFile().toURI()).toString() + File.separator + "compiled-js";
+			
+			String compiledDir = ServiceLocator.getInstance().getConfigurator().getCompiledPath();
+			
+			if(compiledDir == null) // if path is not set use the /classes path
+				compiledDir = new File(new java.io.File(classesFolder).getParentFile().getParentFile().toURI()).toString();
+			
+			final String path= compiledDir + File.separator + "compiled-js";
 
 			LOGGER.log(Level.INFO, "classes: " + path);
 


### PR DESCRIPTION
Some improvements:

#075b808:
1 - Changed classpath filter to obey what is returned when launching with jetty. if its false dont allow classpath to generate.  Its the same issue as #126  where other "\classes" like from bytecode compiler was generating to js even if the filter was set to false.
2 - DefaultDragomeConfigurator now allow classes from "\classes" or "\bin" (Ex: If using dragome as imported project from eclipse).  Was allowing only for jar files. 
3 -  Added the ability to change the compiled javascript files path.  Returning null is the default which it first check for a "\classses" folder and rollback some folders and create a "compiled-js" folder (Same as before).  By returning dir path it will create "compiled-js" in that location. 
4 - fix test to allow "\test-classes" only. "\classes" is already allowed by DefaultDragomeConfigurator 

#2b49830:
1 - Eclipse Jetty plugins was throwing errors that compiler classes was not found. This resolve it. The main problem of this is that dragome-web project mix classes that will get generated and classes that its used to compile. 

#d857cbd
1 - Updated atmosphere dependency. Used 2 jetty plugins and both was causing errors and pointing to atmosphere.  The erros dint prevent from compiling/running though. Updating the dependency stopped the errors from throwing.

#cbec131
Disabled caching for tests.  Most of the time its not detecting changes to classes. For example I rolled back this commit to know why some flexjson classes was missing when launching the tests. The error was causing even after I rolled back. Then I realized that the problem is that the cache file was not updating. 

