### PR TITLE
few improvements

### DIFF
--- a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/Project.java
+++ b/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/Project.java
@@ -527,8 +527,10 @@ public class Project implements Serializable
 		{
 			for (Entry<String, String> entry : typeDecl.getAnnotations().entrySet())
 			{
-				getTypeDeclarationsWithAnnotations().add(typeDecl.getClassName() + "#" + entry.getKey() + "#" + entry.getValue());
-
+				String value = entry.getValue();
+				if(value.isEmpty())
+					value = " ";
+				getTypeDeclarationsWithAnnotations().add(typeDecl.getClassName() + "#" + entry.getKey() + "#" + value);
 			}
 		}
 	}

--- a/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/serverside/JarClasspathEntry.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/compiler/classpath/serverside/JarClasspathEntry.java
@@ -27,12 +27,13 @@ public class JarClasspathEntry extends AbstractClasspathEntry implements Classpa
 	public ClasspathFile getClasspathFileOf(String relativeName)
 	{
 		// There is a "bug" that using getJarEntry with "/" fails and "\\" succeed and vice versa. so solution is to loop all class
+		String tmprelativeName = relativeName.replace("\\", "/");
 		final Enumeration<JarEntry> entries= jarFile.entries();
 		while (entries.hasMoreElements())
 		{
 			final JarEntry entry= entries.nextElement();
 			final String entryName= entry.getName().replace("\\", "/"); // force all path to "/" if its using "\\"
-			if (relativeName.equals(entryName))
+			if (tmprelativeName.equals(entryName))
 				return new InsideJarClasspathFile(jarFile, entry, relativeName);
 		}
 		return null;

--- a/dragome-js-jre/src/main/java/java/lang/String.java
+++ b/dragome-js-jre/src/main/java/java/lang/String.java
@@ -364,6 +364,7 @@ public final class String implements CharSequence, Comparable<String>
 	 */
 	public int indexOf(int strr, int position)
 	{ //FIXME dragome is making char as a int when using charAt( ) so this method is needed or it will give error by saying method dont exist.
+		ScriptHelper.put("strr", strr, this);
 		ScriptHelper.evalNoResult("var str = String.fromCharCode(strr)", this);
 		ScriptHelper.put("position", position, this);
 		return ScriptHelper.evalInt("this.indexOf(str, position)", this);
@@ -554,9 +555,12 @@ public final class String implements CharSequence, Comparable<String>
 	public String[] split(String regex, int maxMatch)
 	{ // from GWT
 		  // The compiled regular expression created from the string
+		ScriptHelper.put("regex", regex, this);
 		Object compiled= ScriptHelper.eval("new RegExp(regex, 'g');", this);
+		ScriptHelper.put("compiled", compiled, this);
 		// the Javascipt array to hold the matches prior to conversion
 		String[] out= new String[0];
+		ScriptHelper.put("out", out, this);
 		// how many matches performed so far
 		int count= 0;
 		// The current string that is being matched; trimmed as each piece matches
@@ -571,6 +575,7 @@ public final class String implements CharSequence, Comparable<String>
 			// None of the information in the match returned are useful as we have no
 			// subgroup handling
 
+			ScriptHelper.put("trail", trail, this);
 			Object matchObj= ScriptHelper.eval("compiled.exec(trail)", this);
 			if (matchObj == null || trail == "" || (count == (maxMatch - 1) && maxMatch > 0))
 			{
@@ -605,6 +610,7 @@ public final class String implements CharSequence, Comparable<String>
 			}
 			if (lastNonEmpty < out.length)
 			{
+				ScriptHelper.put("lastNonEmpty", lastNonEmpty, this);
 				ScriptHelper.evalNoResult("out.length = lastNonEmpty", this);
 			}
 		}
@@ -613,11 +619,14 @@ public final class String implements CharSequence, Comparable<String>
 
 	private static int getMatchIndex(Object matchObject)
 	{
+		ScriptHelper.put("matchObject", matchObject, null);
 		return ScriptHelper.evalInt("matchObject.index", null);
 	};
 
 	private static int getMatchLength(Object matchObject, int index)
 	{
+		ScriptHelper.put("matchObject", matchObject, null);
+		ScriptHelper.put("index", index, null);
 		return ScriptHelper.evalInt("matchObject[index].length", null);
 	};
 


### PR DESCRIPTION
1#  added ScriptHelpear#put in some missing String class methods.  Useful for obfuscating.

2# Finally Fix path comparison.   This backward/forward slash is really crazy.  compiling gdx-test was working fine but compiling my editor project was not. Have no idea what makes each project have different slash path.

3# Fix compiling error when annotation contains a empty string value.  If value is empty and a split is called it will have length 3 and not 4 so accessing key[3] will fail at  https://github.com/dragome/dragome-sdk/blob/69f2e5b2425d17151840969741ec9c6df836ab2a/dragome-bytecode-js-compiler/src/main/java/com/dragome/compiler/writer/Assembly.java#L271-L273