### PR TITLE
Add bcel so it compiles fine

### DIFF
--- a/dragome-web/pom.xml
+++ b/dragome-web/pom.xml
@@ -76,7 +76,11 @@
    <version>1.7.5</version>
   </dependency>
 
-
+  <dependency>
+   <groupId>org.apache.bcel</groupId>
+   <artifactId>bcel</artifactId>
+   <version>6.0</version>
+  </dependency>
 
   <dependency>
    <groupId>javax.websocket</groupId>


### PR DESCRIPTION
In my eclipse maven import I keep getting this error.

```
Exception in thread "Thread-7" java.lang.NoClassDefFoundError: org/apache/bcel/generic/Type
	at com.dragome.compiler.DragomeJsCompiler.configure(DragomeJsCompiler.java:113)
	at com.dragome.web.helpers.serverside.DragomeCompilerLauncher.compileWithMainClass(DragomeCompilerLauncher.java:70)
	at com.dragome.web.serverside.compile.watchers.DirectoryWatcher.compile(DirectoryWatcher.java:263)
	at com.dragome.web.serverside.compile.watchers.DirectoryWatcher.startWatching(DirectoryWatcher.java:249)
	at com.dragome.web.serverside.servlets.CompilerServlet$1.run(CompilerServlet.java:92)
Caused by: java.lang.ClassNotFoundException: org.apache.bcel.generic.Type
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at org.mortbay.jetty.webapp.WebAppClassLoader.loadClass(WebAppClassLoader.java:392)
	at runjettyrun.ProjectClassLoader.loadClass(ProjectClassLoader.java:89)
```

It only stop if I Add bcel to dragome-web pom.