### PR TITLE
Add stack info to objectref#stackTrace when there is a error.

### DIFF
--- a/dragome-js-commons/src/main/resources/dragome/javascript/runtime.js
+++ b/dragome-js-commons/src/main/resources/dragome/javascript/runtime.js
@@ -87,10 +87,19 @@ dragomeJs.nullSaveException = function(objectref) {
 	else if (objectref == null)
 		objectref = dragomeJs.createException("java.lang.NullPointerException",
 				null);
-
-	if (!objectref.message)
-		objectref.message = objectref.$$$message___java_lang_String;
-
+	if (!objectref.message) {
+		var message = objectref.$$$message___java_lang_String;
+		objectref.message = message;
+		var cleanStack = "";
+		try {
+			undefined.b = 1;
+		} catch (e) {
+			var stackSplit = e.stack.split("\n");
+			for(i = 2; i < stackSplit.length;i++)
+				cleanStack = cleanStack+stackSplit[i]+"\n";
+		}
+		objectref.$$$stackTrace___java_lang_String = cleanStack;
+	}
 	return objectref;
 };
 


### PR DESCRIPTION
This is a small change to add stacktrace to Throwable#stackTrace 
so it can be used to print nicely. 

Example:
![image](https://cloud.githubusercontent.com/assets/6472084/21958156/08d3136a-da8e-11e6-9dd6-a212c8e53e5f.png)

I also had to change to use javascript throws ( https://github.com/xpenatan/gdx-dragome-backend/commit/8c431a33ea0740378ad10505ef845995347eb90c#diff-0bd99f4a22e57bef5e8c419f01b47c22R187 )  because it was not printing nicely even without changing runtime.js. 

