### PR TITLE
Obfuscation ready

### DIFF
--- a/dragome-js-commons/src/main/java/com/dragome/commons/DefaultDragomeConfigurator.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/DefaultDragomeConfigurator.java
@@ -33,6 +33,7 @@ public class DefaultDragomeConfigurator implements DragomeConfigurator
 	private CompilerType defaultCompilerType= CompilerType.Standard;
 	private ClasspathFileFilter classpathFilter;
 	private boolean removeUnusedCode;
+	private boolean obfuscateCode;
 
 	public ClassLoader getNewClassloaderInstance(ClassLoader parent, ClassLoader current)
 	{
@@ -147,13 +148,21 @@ public class DefaultDragomeConfigurator implements DragomeConfigurator
 		return removeUnusedCode;
 	}
 
+	public boolean isObfuscateCode()
+	{
+		return obfuscateCode;
+	}
+
 	public void sortClassPath(Classpath classPath)
 	{
 	}
 
-	public URL getAdditionalCodeKeepConfigFile()
+	public void getAdditionalCodeKeepConfigFile(ArrayList<URL> urls)
 	{
-		return null;
+	}
+
+	public void getAdditionalObfuscateCodeKeepConfigFile(ArrayList<URL> urls)
+	{
 	}
 
 	public boolean isCaching() {

--- a/dragome-js-commons/src/main/java/com/dragome/commons/DragomeConfigurator.java
+++ b/dragome-js-commons/src/main/java/com/dragome/commons/DragomeConfigurator.java
@@ -16,6 +16,7 @@
 package com.dragome.commons;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.dragome.commons.compiler.BytecodeTransformer;
@@ -36,8 +37,10 @@ public interface DragomeConfigurator
 	public boolean isCheckingCast();
 	List<ClasspathEntry> getExtraClasspath(Classpath classPath);
 	boolean isRemoveUnusedCode();
+	boolean isObfuscateCode();
 	boolean isCaching();
 	String getCompiledPath();
 	public void sortClassPath(Classpath classPath);
-	URL getAdditionalCodeKeepConfigFile();
+	void getAdditionalCodeKeepConfigFile(ArrayList<URL> urls);
+	void getAdditionalObfuscateCodeKeepConfigFile(ArrayList<URL> urls);
 }

--- a/dragome-js-jre/src/main/java/java/lang/AnnotationInvocationHandler.java
+++ b/dragome-js-jre/src/main/java/java/lang/AnnotationInvocationHandler.java
@@ -30,6 +30,7 @@ public class AnnotationInvocationHandler<T> implements InvocationHandler
 
 	public Object invoke(Object proxy, Method method, Object[] args) throws java.lang.ClassNotFoundException
 	{
+		ScriptHelper.put("method", method, this);
 		String name= method.getName();
 		if (name.equals("toString"))
 		{

--- a/dragome-js-jre/src/main/java/java/lang/Class.java
+++ b/dragome-js-jre/src/main/java/java/lang/Class.java
@@ -334,9 +334,12 @@ public final class Class<T> implements java.io.Serializable, java.lang.reflect.G
 			ScriptHelper.put("signatures", signatures, this);
 			ScriptHelper.eval("for (var e in this.$$$nativeClass___java_lang_Object.$$members) { if (typeof this.$$$nativeClass___java_lang_Object.$$members[e]  === 'function' && e.startsWith('$')) signatures.push(e); }", this);
 			ScriptHelper.eval("for (var e in this.$$$nativeClass___java_lang_Object.prototype) { if (typeof this.$$$nativeClass___java_lang_Object.prototype[e]  === 'function' && e.startsWith('$')) signatures.push(e); }", this);
+			signatures = (String[])ScriptHelper.eval("signatures", this);
 			addMethods(signatures, Modifier.PUBLIC);
 			signatures= new String[0];
+			ScriptHelper.put("signatures", signatures, this);
 			ScriptHelper.eval("for (var e in this.$$$nativeClass___java_lang_Object) { if (typeof this.$$$nativeClass___java_lang_Object[e]  === 'function' && e.startsWith('$')) signatures.push(e); }", this);
+			signatures = (String[])ScriptHelper.eval("signatures", this);
 			addMethods(signatures, Modifier.PUBLIC | Modifier.STATIC);
 		}
 		return declaredMethods.toArray(new Method[0]);

--- a/dragome-js-jre/src/main/java/junit/framework/TestSuite.java
+++ b/dragome-js-jre/src/main/java/junit/framework/TestSuite.java
@@ -379,6 +379,7 @@ public class TestSuite implements Test
 
 	private boolean isTestMethod(Method m)
 	{
-		return m.getParameterTypes().length == 0 && m.getName().startsWith("test") && m.getReturnType().equals(Void.TYPE);
+		org.junit.Test annotation = m.getAnnotation(org.junit.Test.class);
+		return m.getParameterTypes().length == 0 && annotation != null && m.getReturnType().equals(Void.TYPE);
 	}
 }

--- a/dragome-js-jre/src/main/java/org/junit/Test.java
+++ b/dragome-js-jre/src/main/java/org/junit/Test.java
@@ -1,0 +1,22 @@
+package org.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface Test {
+
+	static class None extends Throwable {
+		private static final long serialVersionUID = 1L;
+
+		private None() {
+		}
+	}
+
+	Class<? extends Throwable> expected() default None.class;
+
+	long timeout() default 0L;
+}

--- a/dragome-js-jre/src/test/java/com/dragome/tests/DefaultMethodsTests.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/DefaultMethodsTests.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.dragome.tests;
 
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import junit.framework.TestCase;
@@ -46,6 +47,7 @@ public class DefaultMethodsTests extends TestCase
 		}
 	}
 
+	@Test
 	public void testSuperDefaultMethodIsCalledCorrectly()
 	{
 		String foo= new AB().foo(1);

--- a/dragome-js-jre/src/test/java/com/dragome/tests/LambdaTests.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/LambdaTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import junit.framework.TestCase;
@@ -30,257 +31,274 @@ import junit.framework.TestCase;
 @RunWith(DragomeTestRunner.class)
 public class LambdaTests extends TestCase
 {
-    public void test_empty_lambda()
-    {
-	Runnable lambda= () -> {
-	};
+	@Test
+	public void test_empty_lambda() {
+		Runnable lambda = () -> {
+		};
 
-	lambda.run();
-    }
+		lambda.run();
+	}
 
-    public void test_lambda_returning_a_value() throws Exception
-    {
-	Callable<String> lambda= () -> "some value";
+	@Test
+	public void test_lambda_returning_a_value() throws Exception
+	{
+		Callable<String> lambda = () -> "some value";
 
-	assertEquals("some value", lambda.call());
-    }
+		assertEquals("some value", lambda.call());
+	}
 
-    private interface Function1<IN, OUT>
-    {
-	OUT apply(IN value);
-    }
+	private interface Function1<IN, OUT> {
+		OUT apply(IN value);
+	}
 
-    public void test_lambda_taking_parameters()
-    {
-	Function1<String, Integer> lambda= (String s) -> s.getBytes().length;
+	@Test
+	public void test_lambda_taking_parameters()
+	{
+		Function1<String, Integer> lambda = (String s) -> s.getBytes().length;
 
-	assertEquals((Integer) 3, lambda.apply("foo"));
-    }
+		assertEquals((Integer) 3, lambda.apply("foo"));
+	}
 
-    private int instanceVar= 0;
+	private int instanceVar = 0;
 
-    public void test_lambda_using_instance_variables()
-    {
-	Runnable lambda= () -> {
-	    instanceVar= 42;
-	};
-	lambda.run();
+	@Test
+	public void test_lambda_using_instance_variables()
+	{
+		Runnable lambda = () -> {
+			instanceVar = 42;
+		};
+		lambda.run();
 
-	assertEquals(instanceVar, 42);
-    }
+		assertEquals(instanceVar, 42);
+	}
 
-    public void test_lambda_using_local_variables()
-    {
-	int[] localVar= new int[1];
-	Runnable lambda= () -> {
-	    localVar[0]= 42;
-	};
-	lambda.run();
+	@Test
+	public void test_lambda_using_local_variables()
+	{
+		int[] localVar = new int[1];
+		Runnable lambda = () -> {
+			localVar[0] = 42;
+		};
+		lambda.run();
 
-	assertEquals(localVar[0], 42);
-    }
+		assertEquals(localVar[0], 42);
+	}
 
-    public void test_lambda_using_local_variables_of_primitive_types() throws Exception
-    {
-	boolean bool= true;
-	byte b= 2;
-	short s= 3;
-	int i= 4;
-	long l= 5;
-	float f= 6;
-	double d= 7;
-	char c= 8;
-	Callable<Integer> lambda= () -> (int) ((bool ? 1 : 0) + b + s + i + l + f + d + c);
+	@Test
+	public void test_lambda_using_local_variables_of_primitive_types() throws Exception
+	{
+		boolean bool = true;
+		byte b = 2;
+		short s = 3;
+		int i = 4;
+		long l = 5;
+		float f = 6;
+		double d = 7;
+		char c = 8;
+		Callable<Integer> lambda = () -> (int) ((bool ? 1 : 0) + b + s + i + l + f + d + c);
 
-	Integer call= lambda.call();
-	assertEquals(call, (Integer) 36);
-    }
+		Integer call = lambda.call();
+		assertEquals(call, (Integer) 36);
+	}
 
-    public void test_method_references_to_virtual_methods() throws Exception
-    {
-	String foo= "foo";
-	Callable<String> ref= foo::toUpperCase;
+	@Test
+	public void test_method_references_to_virtual_methods() throws Exception
+	{
+		String foo = "foo";
+		Callable<String> ref = foo::toUpperCase;
 
-	assertEquals(ref.call(), "FOO");
-    }
+		assertEquals(ref.call(), "FOO");
+	}
 
-    public void test_method_references_to_interface_methods() throws Exception
-    {
-	List<String> foos= Arrays.asList("foo");
-	Callable<Integer> ref= foos::size;
+	@Test
+	public void test_method_references_to_interface_methods() throws Exception
+	{
+		List<String> foos = Arrays.asList("foo");
+		Callable<Integer> ref = foos::size;
 
-	Integer result= ref.call();
-	assertEquals(result, (Integer) 1);
-    }
+		Integer result = ref.call();
+		assertEquals(result, (Integer) 1);
+	}
 
-    public void test_method_references_to_static_methods() throws Exception
-    {
-	long expected= System.currentTimeMillis();
-	Callable<Long> ref= System::currentTimeMillis;
+	@Test
+	public void test_method_references_to_static_methods() throws Exception
+	{
+		long expected = System.currentTimeMillis();
+		Callable<Long> ref = System::currentTimeMillis;
 
-	assertTrue(ref.call() >= expected);
-    }
+		assertTrue(ref.call() >= expected);
+	}
 
-    public void test_method_references_to_constructors() throws Exception
-    {
-	Callable<List<String>> ref= ArrayList<String>::new;
+	@Test
+	public void test_method_references_to_constructors() throws Exception
+	{
+		Callable<List<String>> ref = ArrayList<String>::new;
 
-	assertTrue(ref.call() instanceof ArrayList);
-    }
+		assertTrue(ref.call() instanceof ArrayList);
+	}
 
-    class SuperClass
-    {
+	class SuperClass
+	{
+		String inheritedMethod()
+		{
+			return "superclass version";
+		}
+	}
+
+	public class SubClass extends SuperClass
+	{
+		private String t1() throws Exception
+		{
+			Callable<String> ref = super::inheritedMethod;
+			return ref.call();
+		}
+	}
+
+	@Test
+	public void test_method_references_to_overridden_inherited_methods_with_super() throws Exception
+	{
+		SubClass subClass = new SubClass();
+
+		assertEquals(subClass.t1(), "superclass version");
+	}
+
 	String inheritedMethod()
 	{
-	    return "superclass version";
+		return "overridden version";
 	}
-    }
 
-    public class SubClass extends SuperClass
-    {
-	private String t1() throws Exception
+	@Test
+	public void test_method_references_to_private_methods() throws Exception
 	{
-	    Callable<String> ref= super::inheritedMethod;
-	    return ref.call();
+		Callable<String> ref1 = LambdaTests::privateClassMethod;
+		assertEquals(ref1.call(), "foo");
+
+		Callable<String> ref2 = this::privateInstanceMethod;
+		assertEquals(ref2.call(), "foo");
+
+		// Normal method calls should still work after our magic
+		// of making them them accessible from the lambda classes.
+		assertEquals(privateClassMethod(), "foo");
+		assertEquals(privateInstanceMethod(), "foo");
 	}
-    }
 
-    public void test_method_references_to_overridden_inherited_methods_with_super() throws Exception
-    {
-	SubClass subClass= new SubClass();
-
-	assertEquals(subClass.t1(), "superclass version");
-    }
-
-    String inheritedMethod()
-    {
-	return "overridden version";
-    }
-
-    public void test_method_references_to_private_methods() throws Exception
-    {
-	Callable<String> ref1= LambdaTests::privateClassMethod;
-	assertEquals(ref1.call(), "foo");
-
-	Callable<String> ref2= this::privateInstanceMethod;
-	assertEquals(ref2.call(), "foo");
-
-	// Normal method calls should still work after our magic
-	// of making them them accessible from the lambda classes.
-	assertEquals(privateClassMethod(), "foo");
-	assertEquals(privateInstanceMethod(), "foo");
-    }
-
-    public class SomeEntity
-    {
-	protected String name;
-
-	public SomeEntity(String name)
+	public class SomeEntity
 	{
-	    this.name= name;
+		protected String name;
+
+		public SomeEntity(String name)
+		{
+			this.name = name;
+		}
+
+		public int compareTo(SomeEntity entity1)
+		{
+			return name.compareTo(entity1.name);
+		}
 	}
 
-	public int compareTo(SomeEntity entity1)
+	@Test
+	public void test_method_reference_to_instance_comparator() throws Exception
 	{
-	    return name.compareTo(entity1.name);
+		SomeEntity[] a = new SomeEntity[] { new SomeEntity("c"), new SomeEntity("a"), new SomeEntity("b") };
+
+		Arrays.sort(a, SomeEntity::compareTo);
+
+		assertEquals(a[0].name, "a");
+		assertEquals(a[1].name, "b");
+		assertEquals(a[2].name, "c");
 	}
-    }
 
-    public void test_method_reference_to_instance_comparator() throws Exception
-    {
-	SomeEntity[] a= new SomeEntity[] { new SomeEntity("c"), new SomeEntity("a"), new SomeEntity("b") };
+	private String privateInstanceMethod()
+	{
+		return "foo";
+	}
 
-	Arrays.sort(a, SomeEntity::compareTo);
+	private static String privateClassMethod()
+	{
+		return "foo";
+	}
 
-	assertEquals(a[0].name, "a");
-	assertEquals(a[1].name, "b");
-	assertEquals(a[2].name, "c");
-    }
+	@Test
+	public void testLambda_using_instance_variables()
+	{
+		Runnable lambda = () -> {
+			instanceVar = 42;
+		};
+		lambda.run();
 
-    private String privateInstanceMethod()
-    {
-	return "foo";
-    }
+		assertEquals(instanceVar, 42);
+	}
 
-    private static String privateClassMethod()
-    {
-	return "foo";
-    }
+	@Test
+	public void testLambda_using_local_variables()
+	{
+		int[] localVar = new int[1];
+		Runnable lambda = () -> {
+			localVar[0] = 43;
+		};
+		lambda.run();
 
-    public void testLambda_using_instance_variables()
-    {
-	Runnable lambda= () -> {
-	    instanceVar= 42;
-	};
-	lambda.run();
+		assertEquals(localVar[0], 43);
+	}
 
-	assertEquals(instanceVar, 42);
-    }
+	@Test
+	public void testCreatingBinaryOperatorWithLambda()
+	{
+		BinaryOperator<Integer> sum = (v1, v2) -> v1 + v2;
+		Integer result = sum.apply(1, 2);
 
-    public void testLambda_using_local_variables()
-    {
-	int[] localVar= new int[1];
-	Runnable lambda= () -> {
-	    localVar[0]= 43;
-	};
-	lambda.run();
+		assertEquals(new Integer(3), result);
+	}
 
-	assertEquals(localVar[0], 43);
-    }
+	@Test
+	public void testLambaFromLambda()
+	{
+		FileFilter[] filters = new FileFilter[] { f -> f.exists(), f -> f.canRead(), f -> f.getName().startsWith("q") };
 
-    public void testCreatingBinaryOperatorWithLambda()
-    {
-	BinaryOperator<Integer> sum= (v1, v2) -> v1 + v2;
-	Integer result= sum.apply(1, 2);
+		Supplier<Runnable> c = () -> () -> {
+			instanceVar = 80;
+		};
+		Runnable runnable = c.get();
+		runnable.run();
 
-	assertEquals(new Integer(3), result);
-    }
+		assertEquals(80, instanceVar);
+	}
 
-    public void testLambaFromLambda()
-    {
-	FileFilter[] filters= new FileFilter[] { f -> f.exists(), f -> f.canRead(), f -> f.getName().startsWith("q") };
+	@Test
+	public void testNoParametersMethodReferenceAsLambda()
+	{
+		String[] list = new String[] { "One", "Two", "Three", "Four", "Five", "Six" };
 
-	Supplier<Runnable> c= () -> () -> {
-	    instanceVar= 80;
-	};
-	Runnable runnable= c.get();
-	runnable.run();
+		Comparator<String> upperComparator = Comparator.comparing(String::toUpperCase);
 
-	assertEquals(80, instanceVar);
-    }
+		Arrays.sort(list, upperComparator);
 
-    public void testNoParametersMethodReferenceAsLambda()
-    {
-	String[] list= new String[] { "One", "Two", "Three", "Four", "Five", "Six" };
+		assertEquals(list[0], "Five");
+		assertEquals(list[1], "Four");
+		assertEquals(list[2], "One");
+		assertEquals(list[3], "Six");
+		assertEquals(list[4], "Three");
+		assertEquals(list[5], "Two");
+	}
 
-	Comparator<String> upperComparator= Comparator.comparing(String::toUpperCase);
+	@Test
+	public void testUseTwoParametersMethodReferenceAsComparator()
+	{
+		String[] list = new String[] { "One", "Two", "Three", "Four", "Five", "Six" };
+		Arrays.sort(list, (a, b) -> a.substring(1).compareTo(b.substring(1)));
 
-	Arrays.sort(list, upperComparator);
+		assertEquals(list[0], "Three");
+		assertEquals(list[1], "Five");
+		assertEquals(list[2], "Six");
+		assertEquals(list[3], "One");
+		assertEquals(list[4], "Four");
+		assertEquals(list[5], "Two");
+	}
 
-	assertEquals(list[0], "Five");
-	assertEquals(list[1], "Four");
-	assertEquals(list[2], "One");
-	assertEquals(list[3], "Six");
-	assertEquals(list[4], "Three");
-	assertEquals(list[5], "Two");
-    }
-
-    public void testUseTwoParametersMethodReferenceAsComparator()
-    {
-	String[] list= new String[] { "One", "Two", "Three", "Four", "Five", "Six" };
-	Arrays.sort(list, (a, b) -> a.substring(1).compareTo(b.substring(1)));
-
-	assertEquals(list[0], "Three");
-	assertEquals(list[1], "Five");
-	assertEquals(list[2], "Six");
-	assertEquals(list[3], "One");
-	assertEquals(list[4], "Four");
-	assertEquals(list[5], "Two");
-    }
-
-    public static int compareFrom2(String a, String b)
-    {
-	return a.substring(1).compareTo(b.substring(1));
-    }
+	public static int compareFrom2(String a, String b)
+	{
+		return a.substring(1).compareTo(b.substring(1));
+	}
 
 }

--- a/dragome-js-jre/src/test/java/com/dragome/tests/ReflectionAPITests.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/ReflectionAPITests.java
@@ -211,8 +211,17 @@ public class ReflectionAPITests extends TestCase
 	{
 		Class<?>[] interfaces= ReflectionClass.class.getSuperclass().getInterfaces();
 		assertEquals(2, interfaces.length);
-		assertEquals(ReflectionInterface1.class, interfaces[0]);
-		assertEquals(ReflectionInterface2.class, interfaces[1]);
+		Class interface1 = null;
+		Class interface2 = null;
+		// ReflectionInterface1 may not be first so we need to search
+		for(int i = 0; i < interfaces.length;i++) {
+			if(interface1 == null && ReflectionInterface1.class == interfaces[i])
+				interface1 = interfaces[i];
+			if(interface2 == null && ReflectionInterface2.class == interfaces[i])
+				interface2 = interfaces[i];
+		}
+		assertEquals(ReflectionInterface1.class, interface1);
+		assertEquals(ReflectionInterface2.class, interface2);
 	}
 
 	@Test

--- a/dragome-js-jre/src/test/java/com/dragome/tests/ReflectionAPITests.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/ReflectionAPITests.java
@@ -574,4 +574,14 @@ public class ReflectionAPITests extends TestCase
 		}
 
 	}
+
+	@Test
+	public void testGetMethodNoParamCall() throws Exception
+	{
+		long expected = System.currentTimeMillis();
+		Method method = System.class.getMethod("currentTimeMillis");
+		Object invoke = method.invoke(null);
+		Long toExpect = (Long)invoke;
+		assertTrue(toExpect >= expected);
+	}
 }

--- a/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
@@ -1,6 +1,7 @@
 package com.dragome.tests;
 
 import java.net.URL;
+import java.util.ArrayList;
 
 import com.dragome.commons.DragomeConfiguratorImplementor;
 import com.dragome.commons.compiler.classpath.ClasspathFile;
@@ -31,9 +32,22 @@ public class TestsConfigurator extends DomHandlerApplicationConfigurator
 		return true;
 	}
 
-	public URL getAdditionalCodeKeepConfigFile()
+	@Override
+	public boolean isObfuscateCode()
 	{
-		return getClass().getResource("/proguard-extra.conf");
+		return false;
+	}
+
+	@Override
+	public void getAdditionalCodeKeepConfigFile(ArrayList<URL> urls)
+	{
+		urls.add(getClass().getResource("/proguard-extra.conf"));
+	}
+
+	@Override
+	public void getAdditionalObfuscateCodeKeepConfigFile(ArrayList<URL> urls)
+	{
+//		urls.add(getClass().getResource("/proguard-extra.conf"));
 	}
 
 	public boolean filterClassPath(String classpathEntry)

--- a/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
+++ b/dragome-js-jre/src/test/java/com/dragome/tests/TestsConfigurator.java
@@ -47,7 +47,7 @@ public class TestsConfigurator extends DomHandlerApplicationConfigurator
 	@Override
 	public void getAdditionalObfuscateCodeKeepConfigFile(ArrayList<URL> urls)
 	{
-//		urls.add(getClass().getResource("/proguard-extra.conf"));
+		urls.add(getClass().getResource("/proguard-extra.conf"));
 	}
 
 	public boolean filterClassPath(String classpathEntry)

--- a/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
+++ b/dragome-web/src/main/java/com/dragome/web/helpers/serverside/DragomeCompilerLauncher.java
@@ -87,28 +87,34 @@ public class DragomeCompilerLauncher
 
 			try (JarOutputStream jos= new JarOutputStream(new FileOutputStream(file)))
 			{
+				final ArrayList<String> keepClass= new ArrayList<>();
 				final ClasspathFileFilter classpathFilter = configurator.getClasspathFilter();
 				List<ClasspathEntry> entries= classPath.getEntries();
 				for (ClasspathEntry classpathEntry : entries) {
 					classpathEntry.copyFilesToJar(jos, new DefaultClasspathFileFilter()
 					{
-						private ArrayList<String> keepClass= new ArrayList<>();
-
 						public boolean accept(ClasspathFile classpathFile)
 						{
 							boolean result= super.accept(classpathFile);
 
 							String entryName= classpathFile.getPath();
+							entryName = entryName.replace("\\", "/");
+							
 							if (!keepClass.contains(entryName))
 							{
 								keepClass.add(entryName);
 
 								if (entryName.endsWith(".js") || entryName.endsWith(".class") || entryName.contains("MANIFEST") || entryName.contains(".html") || entryName.contains(".css"))
 									result&= true;
+								
+								if(entryName.contains("CollapsableTextWindow$1")) {
+									System.out.println("");
+								}
+								if(classpathFilter != null)
+									result&= classpathFilter.accept(classpathFile);
 							}
-							
-							if(classpathFilter != null)
-								result&= classpathFilter.accept(classpathFile);
+							else 
+								result = false;
 							return result;
 						}
 					});

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -38,12 +38,12 @@
 -keep class java.util.regex.Matcher { *; }
 -keep class java.util.regex.Pattern { *; }
 
--keep class java.util.ArrayList { *; }
+-keepclassmembers enum * { *; }
 
+-keep class java.util.ArrayList { *; }
 
 -keep class java.lang.reflect.* { *; }
 
--repackageclasses 'd'
 -useuniqueclassmembernames
 -keepattributes !LocalVariableTable, !LocalVariableTypeTable, !MethodParameters, !InnerClasses
 -dontshrink

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -53,6 +53,7 @@
 -keep class java.util.regex.Matcher { *; }
 -keep class java.util.regex.Pattern { *; }
 -keep class java.util.ArrayList { *; }
+-keepclassmembers class java.util.function.* { *; }
 
 -keepclassmembers enum * { *; }
 

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -3,13 +3,14 @@
 
 -keep class com.dragome.web.html.dom.w3c.** { *; }
 -keep class com.dragome.web.services.** { *; }
--keep class com.dragome.commons.compiler.annotations.** { *; }
--keep class com.dragome.commons.javascript.** { *; }
--keep class com.dragome.view.** { *; }
 -keep class com.dragome.web.enhancers.jsdelegate.JsCast { *; }
 -keep class com.dragome.web.config.ContextSubTypeFactory { *; }
 -keep class com.dragome.web.config.NodeSubTypeFactory { *; }
--keep class org.w3c.dom.events.Event { *; }
+-keep class com.dragome.commons.compiler.annotations.** { *; }
+-keep class com.dragome.commons.javascript.** { *; }
+-keep class com.dragome.view.** { *; }
+-keep class com.dragome.utils.DragomeCallsiteFactory* { *; }
+
 -keep class com.dragome.web.annotations.PageAlias { *; }
 -keep @com.dragome.web.annotations.PageAlias class *
 -keep class * implements @com.dragome.web.annotations.PageAlias *
@@ -20,6 +21,8 @@
 -keepclassmembers class * {
 	@com.dragome.web.annotations.Keep *;
 }
+
+-keep class junit.** { *; }
 
 -keep class org.w3c.**{ *; }
 
@@ -45,15 +48,12 @@
 -keep class java.lang.invoke.MethodHandles { *; }
 -keep class java.lang.CharSequence { *; }
 -keep class java.lang.Throwable { *; }
-
+-keep class java.lang.reflect.* { *; }
 -keep class java.util.regex.Matcher { *; }
 -keep class java.util.regex.Pattern { *; }
-
--keepclassmembers enum * { *; }
-
 -keep class java.util.ArrayList { *; }
 
--keep class java.lang.reflect.* { *; }
+-keepclassmembers enum * { *; }
 
 -useuniqueclassmembernames
 -keepattributes !LocalVariableTable, !LocalVariableTypeTable, !MethodParameters, !InnerClasses

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -44,11 +44,12 @@
 -keep class java.lang.Deprecated { *; }
 -keep class java.lang.StringBuilder { *; }
 -keep class java.lang.Runnable { *; }
--keep class java.lang.invoke.MethodHandle { *; }
--keep class java.lang.invoke.MethodHandles { *; }
 -keep class java.lang.CharSequence { *; }
 -keep class java.lang.Throwable { *; }
 -keep class java.lang.reflect.* { *; }
+-keep class java.lang.invoke.MethodHandle { *; }
+-keep class java.lang.invoke.MethodHandles { *; }
+-keep class java.lang.AnnotationInvocationHandler { *; }
 -keep class java.util.regex.Matcher { *; }
 -keep class java.util.regex.Pattern { *; }
 -keep class java.util.ArrayList { *; }

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -9,6 +9,17 @@
 -keep class com.dragome.web.enhancers.jsdelegate.JsCast { *; }
 -keep class com.dragome.web.config.ContextSubTypeFactory { *; }
 -keep class com.dragome.web.config.NodeSubTypeFactory { *; }
+-keep class org.w3c.dom.events.Event { *; }
+-keep class com.dragome.web.annotations.PageAlias { *; }
+-keep @com.dragome.web.annotations.PageAlias class *
+-keep class * implements @com.dragome.web.annotations.PageAlias *
+-keep class com.dragome.web.annotations.Keep { *; }
+-keep @com.dragome.web.annotations.Keep class *
+-keep class * implements @com.dragome.web.annotations.Keep *
+-keep class * implements com.dragome.web.annotations.Keep { *; }
+-keepclassmembers class * {
+	@com.dragome.web.annotations.Keep *;
+}
 
 -keep class org.w3c.**{ *; }
 

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -55,6 +55,10 @@
 -keep class java.util.ArrayList { *; }
 -keepclassmembers class java.util.function.* { *; }
 
+-keepclassmembernames class * {
+	private static synthetic *** lambda$*(...);
+}
+
 -keepclassmembers enum * { *; }
 
 -useuniqueclassmembernames

--- a/dragome-web/src/main/resources/proguardObf.conf
+++ b/dragome-web/src/main/resources/proguardObf.conf
@@ -1,0 +1,54 @@
+-injars <in-jar-filename>
+-outjars <out-jar-filename>
+
+-keep class com.dragome.web.html.dom.w3c.** { *; }
+-keep class com.dragome.web.services.** { *; }
+-keep class com.dragome.commons.compiler.annotations.** { *; }
+-keep class com.dragome.commons.javascript.** { *; }
+-keep class com.dragome.view.** { *; }
+-keep class com.dragome.web.enhancers.jsdelegate.JsCast { *; }
+-keep class com.dragome.web.config.ContextSubTypeFactory { *; }
+-keep class com.dragome.web.config.NodeSubTypeFactory { *; }
+
+-keep class org.w3c.**{ *; }
+
+-keep class javascript.Utils { *; }
+
+-keep class java.lang.Object { *; }
+-keep class java.lang.Class { *; }
+-keep class java.lang.String { *; }
+-keep class java.lang.Boolean { *; }
+-keep class java.lang.Integer { *; }
+-keep class java.lang.Void { *; }
+-keep class java.lang.Long { *; }
+-keep class java.lang.Byte { *; }
+-keep class java.lang.Character { *; }
+-keep class java.lang.Float { *; }
+-keep class java.lang.Double { *; }
+-keep class java.lang.Short { *; }
+-keep class java.lang.Comparable { *; }
+-keep class java.lang.Deprecated { *; }
+-keep class java.lang.StringBuilder { *; }
+-keep class java.lang.Runnable { *; }
+-keep class java.lang.invoke.MethodHandle { *; }
+-keep class java.lang.invoke.MethodHandles { *; }
+-keep class java.lang.CharSequence { *; }
+-keep class java.lang.Throwable { *; }
+
+-keep class java.util.regex.Matcher { *; }
+-keep class java.util.regex.Pattern { *; }
+
+-keep class java.util.ArrayList { *; }
+
+
+-keep class java.lang.reflect.* { *; }
+
+-repackageclasses 'd'
+-useuniqueclassmembernames
+-keepattributes !LocalVariableTable, !LocalVariableTypeTable, !MethodParameters, !InnerClasses
+-dontshrink
+-dontoptimize
+-dontpreverify
+-dontnote
+-ignorewarnings
+-dontwarn


### PR DESCRIPTION
#124 
The long waited obfuscation support is here

So what has changed. 

- It first call ClasspathFileFilter to filter classes that should compile.
These classes will be packed to a jar1 file.
Jar1 file will only contains classes that is set to compile.
If shrink is enable it will shrink and make a jar2 file.
If obfuscate is enable it will obfuscate and make a jar3 (with jar2 or jar1) file.
and then it will process the last jar file.

- added "getAdditionalObfuscateCodeKeepConfigFile" and "isObfuscateCode" method for obfuscation

- "getAdditionalCodeKeepConfigFile" and "getAdditionalObfuscateCodeKeepConfigFile" have now a Urls array in param so it can append multiple proguard configs. (usefull so a backend library can add some proguard configs and another project that use this backend append more).


Note:
DefaultClasspathFileFilter in BytecodeToJavascriptCompilerConfiguration  may not require it anymore because it already been filtered so I just added the DefaultClasspathFileFilter because there some reference deep inside the compiler.


Without proguard, libgdx test project javascript size is 12 MB.
With shrink and obfuscate is 3.93 MB.
Using yuicompressor goes down to 3.03 MB.
Total time is about 5-6 seconds.

All gdx backend project will use "-repackageclasses 'x'" config to reduce package name.


Using 2 pass for shrink and Obfuscate makes easier to edit the config file and It didn't work with a single pass because there was a issue with bcel.




 
